### PR TITLE
Kwalitee tweaks

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,7 @@ Scalar::Util = 0
 [GitHub::Update]
 metacpan = 1
 
+[MetaProvides::Package]
 [MinimumPerl]
 [PkgVersion]
 

--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,7 @@ Scalar::Util = 0
 [GitHub::Update]
 metacpan = 1
 
+[MinimumPerl]
 [PkgVersion]
 
 [NextRelease]


### PR DESCRIPTION
[CPANTS](http://cpants.cpanauthors.org/dist/MooseX-Event) listed declaring the minimum Perl version required and provided modules as extra/experimental kwalitee fixes, respectively.  There are dzil plugins to do those, so these commits add them.
